### PR TITLE
feat: use environment variables for API and networks

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,8 @@
 SKIP_PREFLIGHT_CHECK=true
+
+# API endpoint
+REACT_APP_BOLTZ_API=http://localhost:9001
+
+# Network configurations
+REACT_APP_BITCOIN_NETWORK=bitcoinSimnet
+REACT_APP_LITECOIN_NETWORK=litecoinSimnet

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # production
 /build
+.env.production
 
 # misc
 .DS_Store

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,6 +1,6 @@
 import { Networks } from 'boltz-core';
 
-export const boltzApi = 'http://localhost:9001';
+export const boltzApi = process.env.REACT_APP_BOLTZ_API;
 
-export const bitcoinNetwork = Networks.bitcoinSimnet;
-export const litecoinNetwork = Networks.litecoinSimnet;
+export const bitcoinNetwork = Networks[process.env.REACT_APP_BITCOIN_NETWORK];
+export const litecoinNetwork = Networks[process.env.REACT_APP_LITECOIN_NETWORK];


### PR DESCRIPTION
Closes #17 

This makes the API endpoint and networks for Bitcoin and Litecoin configurable with environment variables.

The command `npm run build` that compiles the optimized builds for production [prioritizes the file `.env.production` over the default `.env` file](https://facebook.github.io/create-react-app/docs/adding-custom-environment-variables#what-other-env-files-can-be-used). This way one can configure the production build so that is uses the correct values without making any changes to the files that are in the repository.