### PR TITLE
fix: show errors of failed requests

### DIFF
--- a/src/views/refund/refundActions.js
+++ b/src/views/refund/refundActions.js
@@ -114,8 +114,10 @@ export const startRefund = (
         );
       })
       .catch(error => {
-        window.alert('Failed to refund swap');
-        dispatch(refundResponse(false, error.data));
+        const message = error.response.data.error;
+
+        window.alert(`Failed to refund swap: ${message}`);
+        dispatch(refundResponse(false, message));
       });
   };
 };
@@ -131,8 +133,10 @@ const broadcastRefund = (currency, refundTransaction, cb) => {
       })
       .then(() => cb())
       .catch(error => {
-        window.alert(`Failed to broadcast refund transaction`);
-        dispatch(refundResponse(false, error.data));
+        const message = error.response.data.error;
+
+        window.alert(`Failed to broadcast refund transaction: ${message}`);
+        dispatch(refundResponse(false, message));
       });
   };
 };

--- a/src/views/reverse/reverse.js
+++ b/src/views/reverse/reverse.js
@@ -78,7 +78,9 @@ const ReverseSwap = ({
                   loadingText={swapStatus}
                   loadingRender={() => <Loading />}
                   onPress={() => {
-                    startReverseSwap(swapInfo, props.nextStage);
+                    if (swapInfo.address && swapInfo.address !== '') {
+                      startReverseSwap(swapInfo, props.nextStage);
+                    }
                   }}
                 />
               )}

--- a/src/views/reverse/reverseActions.js
+++ b/src/views/reverse/reverseActions.js
@@ -68,9 +68,10 @@ export const startReverseSwap = (swapInfo, nextStage) => {
         startListening(dispatch, swapInfo, response.data, nextStage);
       })
       .catch(error => {
-        window.alert('Failed to execute swap');
-        console.log(error);
-        dispatch(reverseSwapResponse(false, error.data));
+        const message = error.response.data.error;
+
+        window.alert(`Failed to execute reverse swap: ${message}`);
+        dispatch(reverseSwapResponse(false, message));
       });
   };
 };

--- a/src/views/swap/swapActions.js
+++ b/src/views/swap/swapActions.js
@@ -66,8 +66,10 @@ export const startSwap = (swapInfo, cb) => {
         cb();
       })
       .catch(error => {
-        window.alert('Failed to execute swap');
-        dispatch(swapResponse(false, error.data));
+        const message = error.response.data.error;
+
+        window.alert(`Failed to execute swap: ${message}`);
+        dispatch(swapResponse(false, message));
       });
   };
 };


### PR DESCRIPTION
This PR should cause the errors that pop up when a swap fails to show the actual error message that is returned by the middleware.

![image](https://user-images.githubusercontent.com/8138838/52811259-efeb9e80-3094-11e9-91b0-7d45f532359c.png)
