### PR TITLE
feat: store assets and base amount in local storage

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,7 +19,8 @@
       "Promise": true,
       "window": true,
       "document": true,
-      "navigator": true
+      "navigator": true,
+      "localStorage": true,
     },
     "env": {
       "es6": true,

--- a/src/components/swaptab/index.js
+++ b/src/components/swaptab/index.js
@@ -9,7 +9,6 @@ import DropDown from '../dropdown';
 import Controls from '../controls';
 import Text, { InfoText } from '../text';
 import { decimals } from '../../scripts/utils';
-import { MIN, MAX } from '../../constants/fees';
 
 const styles = theme => ({
   wrapper: {
@@ -145,6 +144,16 @@ class SwapTab extends React.Component {
     )}/${this.parseBoltSuffix(this.state.quote, false)}`;
   };
 
+  componentWillMount() {
+    if (localStorage.length !== 0) {
+      this.setState({
+        base: localStorage.getItem('base'),
+        quote: localStorage.getItem('quote'),
+        baseAmount: localStorage.getItem('baseAmount'),
+      });
+    }
+  }
+
   componentDidMount = () => {
     const symbol = this.getSymbol();
     const limits = this.props.limits[symbol];
@@ -160,6 +169,8 @@ class SwapTab extends React.Component {
   };
 
   componentDidUpdate = (_, prevState) => {
+    const { base, quote, baseAmount } = this.state;
+
     // Update the rate if the request finished or the currencies changed
     if (
       prevState.base !== this.state.base ||
@@ -169,7 +180,7 @@ class SwapTab extends React.Component {
 
       // Swapping from chain to chain or from Lightning to Lightning is not supported right now
       if (
-        this.state.base === this.state.quote ||
+        base === quote ||
         (this.baseAsset.isLightning && this.quoteAsset.isLightning)
       ) {
         this.setState({
@@ -192,8 +203,6 @@ class SwapTab extends React.Component {
       const rate = this.props.rates[symbol];
       const limits = this.props.limits[symbol];
 
-      console.log(this.props);
-
       this.setState(
         {
           rate,
@@ -204,10 +213,16 @@ class SwapTab extends React.Component {
         () => this.updateQuoteAmount(this.state.baseAmount)
       );
     }
+
+    localStorage.setItem('base', base);
+    localStorage.setItem('quote', quote);
+    localStorage.setItem('baseAmount', baseAmount);
   };
 
   checkBaseAmount = baseAmount => {
-    return baseAmount <= MAX && baseAmount >= MIN;
+    const { minAmount, maxAmount } = this.state;
+
+    return baseAmount <= maxAmount && baseAmount >= minAmount;
   };
 
   updatePair = (quote, base) => {


### PR DESCRIPTION
To store the selected assets and entered amount of the user I went with [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage). When opening the site the user should either see the default values if it is the first time the site is opened or the assets selected the last time Boltz was used.