### PR TITLE
fix: validate assets after mounting component

### DIFF
--- a/src/components/background/index.js
+++ b/src/components/background/index.js
@@ -19,7 +19,6 @@ const styles = theme => ({
     lineHeight: 'normal',
     letterSpacing: 'normal',
     alignSelf: 'center',
-    paddingBottom: '10px',
     zIndex: 99999,
   },
 });

--- a/src/components/swaptab/index.js
+++ b/src/components/swaptab/index.js
@@ -164,7 +164,10 @@ class SwapTab extends React.Component {
         maxAmount: limits.maximal,
         rate: this.props.rates[symbol],
       },
-      () => this.updateQuoteAmount(this.state.baseAmount)
+      () => {
+        this.updateQuoteAmount(this.state.baseAmount);
+        this.componentDidUpdate({}, {});
+      }
     );
   };
 
@@ -321,8 +324,6 @@ class SwapTab extends React.Component {
           <MdCompareArrows
             className={classes.arrows}
             onClick={() => {
-              console.log(base);
-              console.log(quote);
               this.setState({
                 base: quote,
                 quote: base,


### PR DESCRIPTION
When selecting two invalid assets, close the window and open Boltz again it should show you the error message again.