### PR TITLE
refactor: remove margin from NodeInfo component

### DIFF
--- a/src/components/nodeinfo/index.js
+++ b/src/components/nodeinfo/index.js
@@ -7,7 +7,6 @@ import QrCode from '../qrcode';
 const styles = theme => ({
   wrapper: {
     height: '300x',
-    width: '700px',
     justifyContent: 'center',
     alignItems: 'center',
     padding: '20px',


### PR DESCRIPTION
This PR removes the margin to the right of the NodeInfo `component`.

@ImmanuelSegol why was there a fixed `width` in the first place? 