### PR TITLE
fix: calculation of base amount

### DIFF
--- a/src/components/swaptab/index.js
+++ b/src/components/swaptab/index.js
@@ -245,13 +245,14 @@ class SwapTab extends React.Component {
 
     const newBase = new BigNumber(quoteAmount).dividedBy(rate).toFixed(8);
     const fee = this.calculateFee(newBase, this.baseAsset.isLightning);
-    const newBaseWithFee = Number((newBase + fee).toFixed(8));
+
+    const newBaseWithFee = (Number(newBase) + fee).toFixed(8);
 
     const inputError = !this.checkBaseAmount(newBaseWithFee);
 
     this.setState({
       quoteAmount: Number(quoteAmount),
-      baseAmount: newBaseWithFee,
+      baseAmount: Number(newBaseWithFee),
       feeAmount: fee,
       inputError,
     });


### PR DESCRIPTION
Inputting a base quote amount ("You receive") throws an error or simply doesn't work if the JavaScript is compiled with `npm run build`. This PR fixed that bug.