### PR TITLE
fix: show webln warning just in console

### DIFF
--- a/src/views/landingpage/landingpage.js
+++ b/src/views/landingpage/landingpage.js
@@ -33,13 +33,7 @@ class LandingPage extends React.Component {
         this.webln = provider;
       });
     } catch (error) {
-      this.addNotification(
-        {
-          message: error.toString(),
-          title: 'Could not enable webln',
-        },
-        1
-      );
+      console.log(`Could not enable WebLN: ${error}`);
     }
   };
 


### PR DESCRIPTION
This PR causes the `Could not enable WebLN` error just to be printed in the console instead of shown to the user because it gets really annoying when one sees it after every reload in a browser that doesn't support webln.