### PR TITLE
fix: fee calculation of quote amount

### DIFF
--- a/src/components/swaptab/index.js
+++ b/src/components/swaptab/index.js
@@ -279,7 +279,7 @@ class SwapTab extends React.Component {
     const { rate } = this.state.rate;
     const fee = this.calculateFee(baseAmount);
 
-    const quote = Number((baseAmount * rate - fee * rate).toFixed(8));
+    const quote = Number((baseAmount * rate - fee).toFixed(8));
 
     const inputError = !this.checkBaseAmount(baseAmount);
 


### PR DESCRIPTION
Closes https://github.com/BoltzExchange/boltz-frontend/issues/144

Once this PR and https://github.com/BoltzExchange/boltz-backend/pull/101 are merged the fee estimation of the `LTC/BTC` should finally be correct