### PR TITLE
refactor: dont cache user input

### DIFF
--- a/src/components/swaptab/index.js
+++ b/src/components/swaptab/index.js
@@ -147,16 +147,6 @@ class SwapTab extends React.Component {
     )}/${this.parseBoltSuffix(this.state.quote, false)}`;
   };
 
-  componentWillMount = () => {
-    if (localStorage.getItem('quote')) {
-      this.setState({
-        base: localStorage.getItem('base'),
-        quote: localStorage.getItem('quote'),
-        baseAmount: localStorage.getItem('baseAmount'),
-      });
-    }
-  };
-
   componentDidMount = () => {
     const symbol = this.getSymbol();
     const limits = this.props.limits[symbol];
@@ -175,7 +165,7 @@ class SwapTab extends React.Component {
   };
 
   componentDidUpdate = (_, prevState) => {
-    const { base, quote, baseAmount } = this.state;
+    const { base, quote } = this.state;
 
     // If rate if undefined disable input
     if (this.state.rate !== prevState.rate) {
@@ -235,10 +225,6 @@ class SwapTab extends React.Component {
           errorMessage: 'Currently not available',
         });
     }
-
-    localStorage.setItem('base', base);
-    localStorage.setItem('quote', quote);
-    localStorage.setItem('baseAmount', baseAmount);
   };
 
   calculateMinerFee = () => {

--- a/src/components/swaptab/index.js
+++ b/src/components/swaptab/index.js
@@ -249,6 +249,7 @@ class SwapTab extends React.Component {
           errorMessage: 'Currently not available',
         });
     }
+
     if (!this.state.inputError) {
       localStorage.setItem('base', base);
       localStorage.setItem('quote', quote);

--- a/src/components/swaptab/index.js
+++ b/src/components/swaptab/index.js
@@ -152,10 +152,19 @@ class SwapTab extends React.Component {
     )}/${this.parseBoltSuffix(this.state.quote, false)}`;
   };
 
+  componentWillMount = () => {
+    if (localStorage.getItem('quote')) {
+      this.setState({
+        base: localStorage.getItem('base'),
+        quote: localStorage.getItem('quote'),
+        baseAmount: localStorage.getItem('baseAmount'),
+      });
+    }
+  };
+
   componentDidMount = () => {
     const symbol = this.getSymbol();
     const limits = this.props.limits[symbol];
-
     this.setState(
       {
         minAmount: limits.minimal,
@@ -170,7 +179,7 @@ class SwapTab extends React.Component {
   };
 
   componentDidUpdate = (_, prevState) => {
-    const { base, quote } = this.state;
+    const { base, quote, baseAmount } = this.state;
 
     // If rate is undefined disable input
     if (this.state.rate !== prevState.rate) {
@@ -239,6 +248,11 @@ class SwapTab extends React.Component {
           error: true,
           errorMessage: 'Currently not available',
         });
+    }
+    if (!this.state.inputError) {
+      localStorage.setItem('base', base);
+      localStorage.setItem('quote', quote);
+      localStorage.setItem('baseAmount', baseAmount);
     }
   };
 


### PR DESCRIPTION
closes #150 

The issue @MikeD123 was talking about where he inputs incorrect data then refreshes and the data persist was due to caching of user input every time, this behavior seems unnecessary to me.

@michael1011 @peartobear Should we add a notification or something to recommend the users install joule? Personally, I don't think we should push a certain product and just make a nice list in the FAQ section. Or write a nice blog post about the options out there @michael1011 ;)