### PR TITLE
fix: trim "lightning:" prefix of invoices

### DIFF
--- a/src/views/swap/steps/inputInvoice.js
+++ b/src/views/swap/steps/inputInvoice.js
@@ -56,9 +56,7 @@ class StyledInputInvoice extends React.Component {
   }
 
   onChange = input => {
-    const valid = input.slice(0, 2);
-
-    if (valid === 'ln') {
+    if (input.slice(0, 2) === 'ln' || input.slice(0, 10) === 'lightning:') {
       this.setState({ value: input, error: false }, () =>
         this.props.onChange(input, false)
       );

--- a/src/views/swap/swapActions.js
+++ b/src/views/swap/swapActions.js
@@ -49,7 +49,12 @@ export const swapRequest = () => ({
 
 export const startSwap = (swapInfo, cb) => {
   const url = `${boltzApi}/createswap`;
-  const { pair, invoice, keys } = swapInfo;
+  let { pair, invoice, keys } = swapInfo;
+
+  // Trim the "lightning:" prefix, that some wallets add in front of their invoices, if it exists
+  if (invoice.slice(0, 10) === 'lightning:') {
+    invoice = invoice.slice(10);
+  }
 
   return dispatch => {
     dispatch(swapRequest());


### PR DESCRIPTION
Closes https://github.com/BoltzExchange/boltz-backend/issues/102

The `lightning:` prefix will be valid in the input field for the invoice and removed before making the request to the middleware.