### PR TITLE
fix: claim transaction when doing two reverse swaps

### DIFF
--- a/src/components/prompt/index.js
+++ b/src/components/prompt/index.js
@@ -4,6 +4,7 @@ const Prompt = () => {
   window.onbeforeunload = () => {
     return true;
   };
+
   return <span style={{ display: 'none' }} />;
 };
 

--- a/src/views/reverse/reverse.js
+++ b/src/views/reverse/reverse.js
@@ -242,7 +242,9 @@ class ReverseSwap extends React.Component {
                     text={'Swap Again!'}
                     onPress={() => {
                       completeSwap();
-                      navigation.navHome();
+
+                      window.onbeforeunload = () => {};
+                      window.location.reload();
                     }}
                   />
                 )}

--- a/src/views/swap/swap.js
+++ b/src/views/swap/swap.js
@@ -53,7 +53,9 @@ class Swap extends Component {
 
   completeSwap = () => {
     this.props.completeSwap();
-    navigation.navHome();
+
+    window.onbeforeunload = () => {};
+    window.location.reload();
   };
 
   render() {


### PR DESCRIPTION
When doing  two reverse swaps consecutively without reloading the page claiming the swap output failed. This fixes that bug by forcing the page to reload when clicking on *"Swap again"*