### PR TITLE
fix: trim prefix of scanned QR code data

### DIFF
--- a/src/components/inputarea/index.js
+++ b/src/components/inputarea/index.js
@@ -78,6 +78,10 @@ class InputArea extends React.Component {
     if (data !== null) {
       console.log(`Scanned QR code: ${data}`);
 
+      if (data.includes(':')) {
+        data = data.split(':')[1];
+      }
+
       this.props.onChange(data);
 
       this.setState({


### PR DESCRIPTION
Because some QR codes have a prefix like "bitcoin:" or "litecoin:" this commit causes all prefixes to be removed after a QR code is scanned.